### PR TITLE
Remove subdivision display from search results

### DIFF
--- a/src/components/I-TeacherCard/I-TeacherCard.tsx
+++ b/src/components/I-TeacherCard/I-TeacherCard.tsx
@@ -15,8 +15,6 @@ const ITeacherCard: React.FC<Props> = ({ teacherInfo, className = '' }) => {
             <div className={'cursor-pointer max-w-160 ' + className}>
                 <Avatar img={teacherInfo.photo} />
                 <div className="text-semibold">{teacherInfo.fullName}</div>
-                <div className="mt-1 text-sm text-neutral-900">{teacherInfo.positions[0].name}</div>
-                <div className="mt-2 text-xs text-neutral-600">{teacherInfo.positions[0].subdivision.name}</div>
             </div>
         </Link>
     );


### PR DESCRIPTION
This pull request makes a minor change to the `ITeacherCard` component by removing the display of the teacher's position and subdivision information. Now, only the teacher's photo and full name are shown.