### PR TITLE
Disable LocaleSwitcher component in Header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -71,11 +71,11 @@ const Header: React.FC<Props> = ({ scheme = 'dark', underlined = true }) => {
                 <div className="flex items-center gap-6 h-full">
                     <div className="hidden xs:flex items-center gap-6">
                         {navigation}
-                        <LocaleSwitcher />
+                        {/* <LocaleSwitcher /> */}
                     </div>
 
                     <div className="xs:hidden flex items-center gap-4">
-                        <LocaleSwitcher />
+                        {/* <LocaleSwitcher /> */}
                         <Burger
                             onBurgerClick={(value) => toggleCollapse(value)}
                             collapsed={burgerCollapsed}


### PR DESCRIPTION
## Summary
Temporarily disabled the `LocaleSwitcher` component in the Header by commenting out its usage in both desktop and mobile layouts.

## Changes
- Commented out `<LocaleSwitcher />` in the desktop navigation section (hidden on xs breakpoint)
- Commented out `<LocaleSwitcher />` in the mobile navigation section (visible only on xs breakpoint)

## Notes
The component remains imported but is no longer rendered in either responsive layout variant. This appears to be a temporary measure, as the code is commented out rather than removed entirely.