### PR TITLE
Refactor layout and improve spacing for components

### DIFF
--- a/src/app/[locale]/(default)/layout.tsx
+++ b/src/app/[locale]/(default)/layout.tsx
@@ -8,7 +8,7 @@ export default function DefaultLayout({ children }: { children: React.ReactNode 
     return (
         <TooltipProvider>
             <Header scheme="dark" />
-            <div className="wrapper px-4">{children}</div>
+            <div className="wrapper">{children}</div>
         </TooltipProvider>
     );
 }

--- a/src/app/[locale]/(default)/layout.tsx
+++ b/src/app/[locale]/(default)/layout.tsx
@@ -8,7 +8,7 @@ export default function DefaultLayout({ children }: { children: React.ReactNode 
     return (
         <TooltipProvider>
             <Header scheme="dark" />
-            <div className="wrapper">{children}</div>
+            <div className="wrapper px-4">{children}</div>
         </TooltipProvider>
     );
 }

--- a/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
+++ b/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getTeacherByTeacherId } from '@/api/teacher';
-import { API_BASE_URL } from '@/api/index';
+import { API_BASE_URL } from '@/api';
 import SectionTitle from '@/components/common/SectionTitle';
 import { JobLabel } from '@/components/JobLabel/JobLabel';
 import Avatar from '@/components/Avatar/Avatar';
@@ -44,7 +44,7 @@ const generateMetaDescription = (teacher: Lecturer | null, t: any): string => {
 
 export async function generateMetadata({ params }: { params: Promise<{ teacherId: string; locale: string }> }): Promise<Metadata> {
     const { teacherId, locale } = await params;
-    const t = await getTranslations({ locale, namespace: 'profile' });
+    await getTranslations({ locale, namespace: 'profile' });
     const commonT = await getTranslations({ locale, namespace: 'global.metadata' });
 
     try {

--- a/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
+++ b/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
@@ -94,7 +94,7 @@ export default async function TeacherProfilePage({ params }: { params: Promise<{
                     </BreadcrumbList>
                 </Breadcrumb>
                 <div className="grid grid-cols-[1fr] sm:grid-cols-[170px_1fr] gap-6 mt-6 justify-items-center sm:justify-items-start relative">
-                    <div>
+                    <div className="w-48 sm:w-full">
                         <Avatar img={teacher?.photo} />
                     </div>
                     <div className="w-full overflow-x-hidden">

--- a/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
+++ b/src/app/[locale]/(default)/profile/[teacherId]/page.tsx
@@ -44,7 +44,6 @@ const generateMetaDescription = (teacher: Lecturer | null, t: any): string => {
 
 export async function generateMetadata({ params }: { params: Promise<{ teacherId: string; locale: string }> }): Promise<Metadata> {
     const { teacherId, locale } = await params;
-    await getTranslations({ locale, namespace: 'profile' });
     const commonT = await getTranslations({ locale, namespace: 'global.metadata' });
 
     try {

--- a/src/app/[locale]/(default)/search/page.tsx
+++ b/src/app/[locale]/(default)/search/page.tsx
@@ -143,7 +143,7 @@ const SearchContent: React.FC = () => {
     };
 
     return (
-        <section className="pt-12 pb-20 px-4 wrapper">
+        <section className="pt-12 pb-20 wrapper">
             <RoutePointer routePath={route} />
             <div className="mt-4">
                 <Alphabet onLetterSelected={(e) => onSubmit(searchStringParams.STARTS_WITH + e, true, false)} />

--- a/src/app/[locale]/(default)/search/page.tsx
+++ b/src/app/[locale]/(default)/search/page.tsx
@@ -121,7 +121,7 @@ const SearchContent: React.FC = () => {
             return (
                 <SearchGrid className="mt-6">
                     {teachers.map((item, idx) => (
-                        <ITeacherCard className="justify-self-center" key={idx} teacherInfo={item} />
+                        <ITeacherCard key={idx} teacherInfo={item} />
                     ))}
                 </SearchGrid>
             );

--- a/src/app/[locale]/global.css
+++ b/src/app/[locale]/global.css
@@ -330,6 +330,8 @@ html {
   max-width: 1235px;
   width: 100%;
   margin: 0 auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .header-wrapper {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -10,7 +10,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
     return (
         <div className="text-white header-wrapper">
             <Header underlined={false} scheme="light" />
-            <div className="wrapper">
+            <div className="wrapper px-4">
                 <ISearchBlock />
             </div>
         </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -11,7 +11,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
         <>
             <div className="text-white header-wrapper">
                 <Header underlined={false} scheme="light" />
-                <div className="wrapper px-4">
+                <div className="wrapper">
                     <ISearchBlock />
                 </div>
             </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,11 +8,14 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
     setRequestLocale(locale);
 
     return (
-        <div className="text-white header-wrapper">
-            <Header underlined={false} scheme="light" />
-            <div className="wrapper px-4">
-                <ISearchBlock />
+        <>
+            <div className="text-white header-wrapper">
+                <Header underlined={false} scheme="light" />
+                <div className="wrapper px-4">
+                    <ISearchBlock />
+                </div>
             </div>
-        </div>
+            <div className="min-h-[100px]" />
+        </>
     );
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -8,9 +8,10 @@ const AVATAR_STUB_URL = `${CDN_IMG_BASE}/avatar-stub.png`;
 
 type Props = {
     img?: string;
+    alt?: string;
 };
 
-const Avatar: React.FC<Props> = ({ img }) => {
+const Avatar: React.FC<Props> = ({ img, alt }) => {
     const [src, setSrc] = useState(img || AVATAR_STUB_URL);
 
     useEffect(() => {
@@ -18,11 +19,11 @@ const Avatar: React.FC<Props> = ({ img }) => {
     }, [img]);
 
     return (
-        <div className="w-[170px] h-[200px]">
+        <div className="aspect-[3/4]">
             <Image
                 className="object-cover w-full h-full border-[1px] border-solid border-[#eee] rounded-[5px]"
                 src={src}
-                alt="avatar"
+                alt={alt || 'Avatar'}
                 width={0}
                 height={0}
                 sizes="100vw"

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC<Props> = ({ logoSrc }) => {
     const currentYear = new Date().getFullYear();
 
     return (
-        <footer className="bg-primary text-white text-sm">
+        <footer className="bg-primary text-white text-sm px-4">
             <div className="wrapper flex sm:flex-row sm:text-left text-center flex-col justify-between py-9 gap-9">
                 <Image className="max-w-120 mx-auto" src={logoSrc} alt="logo" />
                 <section>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -61,7 +61,7 @@ const Header: React.FC<Props> = ({ scheme = 'dark', underlined = true }) => {
     };
 
     return (
-        <header className={'h-100 ' + (underlined ? 'header' : '')}>
+        <header className={'h-100 px-4 ' + (underlined ? 'header' : '')}>
             <div className="flex justify-between wrapper h-full items-center">
                 <Link className="cursor-pointer" href="/">
                     <Image src={logoSrc} alt={t('logo')} />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,6 +6,7 @@ import './Header.module.css';
 import { useTranslations, useLocale } from 'next-intl';
 
 import Burger from '../Burger/Burger';
+import { cn } from '@/lib/utils';
 
 import darkLogoUk from '@/assets/svg/intellect-logo-dark-uk.svg';
 import darkLogoEn from '@/assets/svg/intellect-logo-dark-en.svg';
@@ -61,7 +62,7 @@ const Header: React.FC<Props> = ({ scheme = 'dark', underlined = true }) => {
     };
 
     return (
-        <header className={'h-100 px-4 ' + (underlined ? 'header' : '')}>
+        <header className={cn('h-100 px-4', underlined && 'header')}>
             <div className="flex justify-between wrapper h-full items-center">
                 <Link className="cursor-pointer" href="/">
                     <Image src={logoSrc} alt={t('logo')} />

--- a/src/components/I-TeacherCard/I-TeacherCard.tsx
+++ b/src/components/I-TeacherCard/I-TeacherCard.tsx
@@ -11,11 +11,9 @@ type Props = {
 
 const ITeacherCard: React.FC<Props> = ({ teacherInfo, className = '' }) => {
     return (
-        <Link className="w-full" href={'/profile/' + teacherInfo.userIdentifier}>
-            <div className={'cursor-pointer max-w-160 ' + className}>
-                <Avatar img={teacherInfo.photo} alt={teacherInfo.fullName} />
-                <div className="text-semibold">{teacherInfo.fullName}</div>
-            </div>
+        <Link className={'block cursor-pointer ' + className} href={'/profile/' + teacherInfo.userIdentifier}>
+            <Avatar img={teacherInfo.photo} alt={teacherInfo.fullName} />
+            <div className="text-semibold">{teacherInfo.fullName}</div>
         </Link>
     );
 };

--- a/src/components/I-TeacherCard/I-TeacherCard.tsx
+++ b/src/components/I-TeacherCard/I-TeacherCard.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const ITeacherCard: React.FC<Props> = ({ teacherInfo, className = '' }) => {
     return (
-        <Link className="mx-auto w-fit" href={'/profile/' + teacherInfo.userIdentifier}>
+        <Link className="w-full" href={'/profile/' + teacherInfo.userIdentifier}>
             <div className={'cursor-pointer max-w-160 ' + className}>
                 <Avatar img={teacherInfo.photo} alt={teacherInfo.fullName} />
                 <div className="text-semibold">{teacherInfo.fullName}</div>

--- a/src/components/I-TeacherCard/I-TeacherCard.tsx
+++ b/src/components/I-TeacherCard/I-TeacherCard.tsx
@@ -2,6 +2,7 @@ import { Link } from '@/i18n/routing';
 import React from 'react';
 
 import Avatar from '@/components/Avatar/Avatar';
+import { cn } from '@/lib/utils';
 import { Lecturer } from '@/types/intellect';
 
 type Props = {
@@ -9,9 +10,9 @@ type Props = {
     className?: string;
 };
 
-const ITeacherCard: React.FC<Props> = ({ teacherInfo, className = '' }) => {
+const ITeacherCard: React.FC<Props> = ({ teacherInfo, className }) => {
     return (
-        <Link className={'block cursor-pointer ' + className} href={'/profile/' + teacherInfo.userIdentifier}>
+        <Link className={cn('block cursor-pointer', className)} href={'/profile/' + teacherInfo.userIdentifier}>
             <Avatar img={teacherInfo.photo} alt={teacherInfo.fullName} />
             <div className="text-semibold">{teacherInfo.fullName}</div>
         </Link>

--- a/src/components/I-TeacherCard/I-TeacherCard.tsx
+++ b/src/components/I-TeacherCard/I-TeacherCard.tsx
@@ -13,7 +13,7 @@ const ITeacherCard: React.FC<Props> = ({ teacherInfo, className = '' }) => {
     return (
         <Link className="mx-auto w-fit" href={'/profile/' + teacherInfo.userIdentifier}>
             <div className={'cursor-pointer max-w-160 ' + className}>
-                <Avatar img={teacherInfo.photo} />
+                <Avatar img={teacherInfo.photo} alt={teacherInfo.fullName} />
                 <div className="text-semibold">{teacherInfo.fullName}</div>
             </div>
         </Link>


### PR DESCRIPTION
This pull request focuses on improving layout consistency, accessibility, and code cleanliness across several components. The main changes include standardized padding for page wrappers and headers, improved accessibility for avatars, and some minor refactoring of card and grid layouts.

**Layout and Styling Improvements:**
* Added horizontal padding (`px-4`) to the main page wrapper, `Header`, and `Footer` components for consistent spacing across the site. ([src/app/[locale]/global.cssR333-R334](diffhunk://#diff-7212fa12d64cfaa0762bc001bbe1c81ba2686f48209cfcd9ac7989b3a8b7a7bfR333-R334), [[1]](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL64-R64) [[2]](diffhunk://#diff-eaddc41bc22d344d709d06ba973003d5cb83c6dd8de442594e5ec35dba0db3fcL15-R15)
* Removed redundant padding from the `SearchContent` section to avoid double padding, since the wrapper now handles it. ([src/app/[locale]/(default)/search/page.tsxL146-R146](diffhunk://#diff-8d011f6996ea259fec468a4e7deb353e15310a63adceeb2a9fe6fd29a4cfb9fdL146-R146))

**Accessibility Enhancements:**
* Updated the `Avatar` component to accept an `alt` prop and pass the teacher’s name as the alt text, improving accessibility for screen readers. [[1]](diffhunk://#diff-5bde686e06876f3828b15fa207e4300b2947e5e520e076ce0f7de9e5fcc1bc2eR11-R26) [[2]](diffhunk://#diff-eff86d0e66628ebbb96120aecb8af660a89441a7e7f798e28815ce7cd11b13e2L14-L18)

**Component and Layout Refactoring:**
* Simplified the `ITeacherCard` structure by flattening the markup and removing unnecessary wrappers, and ensured the card is a block-level link for better clickability.
* Adjusted the grid and card layouts in the search page for a cleaner and more consistent appearance by removing extra centering classes. ([src/app/[locale]/(default)/search/page.tsxL124-R124](diffhunk://#diff-8d011f6996ea259fec468a4e7deb353e15310a63adceeb2a9fe6fd29a4cfb9fdL124-R124))

**Minor UI Improvements:**
* Added a minimum height spacer under the header on the home page to improve visual separation. ([src/app/[locale]/page.tsxR11-R19](diffhunk://#diff-60f04e167ad0f41b936cc3ffdf6ebaf028f2779240625a2e5f50a1b754bb0fa7R11-R19))