### PR TITLE
KB-1260 Read X-Total-Count header from /v2/find instead of envelope

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { getLocale } from 'next-intl/server';
 import { DEFAULT_LOCALE, LOCALES } from '@/i18n/routing';
 
@@ -17,16 +17,28 @@ const getLocaleSafe = async () => {
     }
 };
 
+const attachLocale = (instance: AxiosInstance) => {
+    instance.interceptors.request.use(async (config) => {
+        const locale = await getLocaleSafe();
+        config.headers.set('Accept-Language', locale);
+        return config;
+    });
+};
+
 const Http = axios.create({
     baseURL: API_BASE_URL + '/intellect/',
 });
 
-Http.interceptors.request.use(async (config) => {
-    const locale = await getLocaleSafe();
-    config.headers.set('Accept-Language', locale);
-    return config;
+attachLocale(Http);
+Http.interceptors.response.use((res) => res.data);
+
+// Same baseURL and locale handling as Http, but without the response
+// interceptor — callers see the full AxiosResponse so they can read
+// pagination headers (X-Total-Count etc.).
+export const HttpRaw = axios.create({
+    baseURL: API_BASE_URL + '/intellect/',
 });
 
-Http.interceptors.response.use((res) => res.data);
+attachLocale(HttpRaw);
 
 export default Http;

--- a/src/api/teacher.ts
+++ b/src/api/teacher.ts
@@ -1,10 +1,15 @@
 import { ApiResponse } from '@/types/ecampus';
-import Http from './index';
+import Http, { HttpRaw } from './index';
 
 import { parseSearchParams } from '@/utils';
 import { Rating, Lecturer, EvaluationWorkload } from '@/types/intellect';
 
-export const searchByInput = (input: string, currentPage: number): Promise<ApiResponse<Lecturer>> => {
+// Backend returns the page as a plain array and exposes the total row
+// count via the X-Total-Count header. Keep the pageSize the client uses
+// pinned here so pageCount math stays internally consistent.
+const SEARCH_PAGE_SIZE = 30;
+
+export const searchByInput = async (input: string, currentPage: number): Promise<ApiResponse<Lecturer>> => {
     const params = parseSearchParams(input);
     let searchString = '?';
 
@@ -14,7 +19,17 @@ export const searchByInput = (input: string, currentPage: number): Promise<ApiRe
         searchString += '&value=' + input;
     }
 
-    return Http.get('/v2/find' + searchString + `&pageNumber=${currentPage}`);
+    const response = await HttpRaw.get<Lecturer[]>(
+        '/v2/find' + searchString + `&pageNumber=${currentPage}&pageSize=${SEARCH_PAGE_SIZE}`,
+    );
+
+    const totalCount = parseInt(response.headers['x-total-count'] ?? '0', 10);
+    const pageCount = totalCount > 0 ? Math.ceil(totalCount / SEARCH_PAGE_SIZE) : 0;
+
+    return {
+        data: response.data,
+        paging: { pageNumber: currentPage, pageCount },
+    };
 };
 
 export const getTeacherByTeacherId = (teacherId: string): Promise<Lecturer> => {


### PR DESCRIPTION
Backend dropped the IntellectSearchResponse envelope; the page is now a plain array body with the row count in the X-Total-Count response header. Adds an HttpRaw axios instance (same baseURL and locale interceptor as Http, but without the response unwrap) so searchByInput can read the header. The function still returns ApiResponse<Lecturer> so the search page and InputField don't have to change — pageCount is computed inside the API client from total / pageSize.

The client now sends pageSize explicitly so the math stays consistent with whatever the backend uses for that page.