### PR TITLE
KB-1534 Group workload sections by employment type

### DIFF
--- a/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsx
+++ b/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsx
@@ -13,7 +13,6 @@ import {
     getDefaultDepartment,
     getDefaultYearFromGrouped,
     getEmploymentAbbreviation,
-    getSectionBravoId,
     getSectionEmploymentType,
     groupWorkloadsByYearRange,
 } from './utils';
@@ -127,36 +126,36 @@ export const WorkloadDetails: FC<Props> = ({ workloads, ratings = [], positions 
 
             {sections.main.grouped.length > 0 && (
                 <div className="mt-8">
-                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(positions, getSectionBravoId(sections.main.grouped))}`)}</SectionTitle>
+                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(sections.main.grouped, positions)}`)}</SectionTitle>
                     <DataTable groupedWorkloads={sections.main.grouped} hideTitle />
                     <StackedBarChart
                         yearRange={selectedYear}
                         summary={computeWorkloadSummary(sections.main.workloads)}
-                        appointmentAbbreviation={getEmploymentAbbreviation(positions, getSectionBravoId(sections.main.grouped))}
+                        appointmentAbbreviation={getEmploymentAbbreviation(sections.main.grouped, positions)}
                     />
                 </div>
             )}
 
             {sections.mixed.grouped.length > 0 && (
                 <div className="mt-8">
-                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(positions, getSectionBravoId(sections.mixed.grouped))}`)}</SectionTitle>
+                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(sections.mixed.grouped, positions)}`)}</SectionTitle>
                     <DataTable groupedWorkloads={sections.mixed.grouped} hideTitle variant="mixed" />
                     <StackedBarChart
                         yearRange={selectedYear}
                         summary={computeWorkloadSummary(sections.mixed.workloads)}
-                        appointmentAbbreviation={getEmploymentAbbreviation(positions, getSectionBravoId(sections.mixed.grouped))}
+                        appointmentAbbreviation={getEmploymentAbbreviation(sections.mixed.grouped, positions)}
                     />
                 </div>
             )}
 
             {sections.hourly.grouped.length > 0 && (
                 <div className="mt-8">
-                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(positions, getSectionBravoId(sections.hourly.grouped))}`)}</SectionTitle>
+                    <SectionTitle className="mb-4 uppercase text-primary">{t(`employment_types.${getSectionEmploymentType(sections.hourly.grouped, positions)}`)}</SectionTitle>
                     <DataTable groupedWorkloads={sections.hourly.grouped} hideTitle variant="hourly" />
                     <StackedBarChart
                         yearRange={selectedYear}
                         summary={computeWorkloadSummary(sections.hourly.workloads)}
-                        appointmentAbbreviation={getEmploymentAbbreviation(positions, getSectionBravoId(sections.hourly.grouped))}
+                        appointmentAbbreviation={getEmploymentAbbreviation(sections.hourly.grouped, positions)}
                         onlyEducational
                     />
                 </div>

--- a/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/useGroupedWorkloads.ts
+++ b/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/useGroupedWorkloads.ts
@@ -1,7 +1,30 @@
 import { useMemo } from 'react';
-import { EvaluationWorkload } from '@/types/intellect';
+import { EmploymentType, EvaluationWorkload } from '@/types/intellect';
 
 export type WorkloadGroupType = { normative?: EvaluationWorkload; mixed?: EvaluationWorkload; hourly?: EvaluationWorkload };
+
+type WorkloadBucket = 'normative' | 'mixed' | 'hourly';
+
+/**
+ * Buckets a workload row by its employment form: primary appointment (normative),
+ * secondary appointment (mixed) or hourly. Rows cached before the API exposed a
+ * usable employment value fall back to the old salary-based heuristic.
+ */
+const getWorkloadBucket = (w: EvaluationWorkload): WorkloadBucket => {
+    switch (w.employment) {
+        case EmploymentType.FullTime:
+            return 'normative';
+        case EmploymentType.PartTime:
+        case EmploymentType.PartTimeInternal:
+        case EmploymentType.PartTimeExternal:
+            return 'mixed';
+        case EmploymentType.HourlyPay:
+            return 'hourly';
+        default:
+            if (w.salary === 0) return 'hourly';
+            return w.salary >= 1 ? 'normative' : 'mixed';
+    }
+};
 
 export const useGroupedWorkloads = (workloads: EvaluationWorkload[], selectedPeriod: string) => {
     return useMemo(() => {
@@ -38,25 +61,13 @@ export const useGroupedWorkloads = (workloads: EvaluationWorkload[], selectedPer
             if (!group.semesters[w.semester]) group.semesters[w.semester] = {};
             const semGroup = group.semesters[w.semester];
 
-            if (w.salary === 0) {
-                if (!semGroup.hourly) semGroup.hourly = { ...w };
-                else accumulate(semGroup.hourly, w);
+            const bucket = getWorkloadBucket(w);
 
-                if (!group.total.hourly) group.total.hourly = { ...w, semester: 0 };
-                else accumulate(group.total.hourly, w);
-            } else if (w.salary >= 1) {
-                if (!semGroup.normative) semGroup.normative = { ...w };
-                else accumulate(semGroup.normative, w);
+            if (!semGroup[bucket]) semGroup[bucket] = { ...w };
+            else accumulate(semGroup[bucket]!, w);
 
-                if (!group.total.normative) group.total.normative = { ...w, semester: 0 };
-                else accumulate(group.total.normative, w);
-            } else {
-                if (!semGroup.mixed) semGroup.mixed = { ...w };
-                else accumulate(semGroup.mixed, w);
-
-                if (!group.total.mixed) group.total.mixed = { ...w, semester: 0 };
-                else accumulate(group.total.mixed, w);
-            }
+            if (!group.total[bucket]) group.total[bucket] = { ...w, semester: 0 };
+            else accumulate(group.total[bucket]!, w);
         });
 
         Object.values(subgroups).forEach((group) => {

--- a/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/utils.ts
+++ b/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/utils.ts
@@ -134,17 +134,6 @@ export const computeWorkloadSummary = (workloads: EvaluationWorkload[]): Workloa
 }
 
 /**
- * Finds the employment abbreviation (PA/SA/HA) for a given subdivision bravoId
- * by looking it up in the teacher's positions list.
- */
-export const getEmploymentAbbreviation = (positions: Position[], bravoId: number | undefined): string => {
-    if (!bravoId) return '';
-    const match = positions.find((p) => p.subdivision?.bravoId === bravoId);
-    if (!match) return '';
-    return EMPLOYMENT_ABBREVIATION[match.employment] ?? '';
-};
-
-/**
  * Extracts the subdivision bravoId from the first available workload in a grouped section.
  */
 export const getSectionBravoId = (grouped: WorkloadGroupType[]): number | undefined => {
@@ -156,11 +145,31 @@ export const getSectionBravoId = (grouped: WorkloadGroupType[]): number | undefi
 };
 
 /**
- * Returns the EmploymentType enum key for a given subdivision bravoId,
- * used to look up the full translated label via t('employment_types.{key}').
+ * Returns the EmploymentType of a grouped section, used to look up the full
+ * translated label via t('employment_types.{key}').
+ *
+ * The value comes from the workload rows themselves, so a teacher with several
+ * employment records at the same subdivision gets the right label per section.
+ * Rows cached before the API exposed a usable employment value fall back to a
+ * lookup in the teacher's positions list by subdivision bravoId.
  */
-export const getSectionEmploymentType = (positions: Position[], bravoId: number | undefined): EmploymentType => {
+export const getSectionEmploymentType = (grouped: WorkloadGroupType[], positions: Position[]): EmploymentType => {
+    for (const g of grouped) {
+        const workload = g.normative ?? g.mixed ?? g.hourly;
+        if (workload && workload.employment && workload.employment !== EmploymentType.Unknown) {
+            return workload.employment;
+        }
+    }
+
+    const bravoId = getSectionBravoId(grouped);
     if (!bravoId) return EmploymentType.Unknown;
     const match = positions.find((p) => p.subdivision?.bravoId === bravoId);
     return match?.employment ?? EmploymentType.Unknown;
+};
+
+/**
+ * Returns the employment abbreviation (PA/SA/HA) of a grouped section.
+ */
+export const getEmploymentAbbreviation = (grouped: WorkloadGroupType[], positions: Position[]): string => {
+    return EMPLOYMENT_ABBREVIATION[getSectionEmploymentType(grouped, positions)] ?? '';
 };


### PR DESCRIPTION
Jira: [KB-1534](https://kpiua.atlassian.net/browse/KB-1534)

## Summary
- Workload rows are placed into the PA / SA / HA sections by the `employment` field of the row itself, not by the size of the rate. The old heuristic (0 = hourly, >= 1 = normative, fractional = mixed) mislabels records now that rates are fractional (e.g. a 0.5 full-time record went to the SA section).
- Section titles and chart badges (PA/SA/HA) also come from the workload rows. Before, they were looked up in the positions list by subdivision, and `find` returned the first match, so a lecturer with two employment records at one department got the wrong badge.
- The positions-list lookup is kept as a fallback for rows cached before the API exposed a usable employment value.

## Notes
- Needs the linked my.kpi.ua and api.campus PRs: without them the API reports `FullTime`/`Unknown` for everything, and the fallback keeps the old behavior.
- `tsc --noEmit` passes.

## Related PRs
- my.kpi.ua: [PR #209](https://github.com/kpi-ua/my.kpi.ua/pull/209)
- api.campus.kpi.ua: [PR #842](https://github.com/kpi-ua/api.campus.kpi.ua/pull/842)


[KB-1534]: https://kpiua.atlassian.net/browse/KB-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ