### PR TITLE
KBX-1038 workload tab wrong default filters hide data and crash the page

### DIFF
--- a/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsx
+++ b/src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsx
@@ -44,7 +44,7 @@ export const WorkloadDetails: FC<Props> = ({ workloads, ratings = [], positions 
     const [selectedPeriod, setSelectedPeriod] = useState('0');
 
     const filteredWorkloads = useMemo(() => {
-        const currentWorkloads = workloadsByYearRange ? workloadsByYearRange[selectedYear] : [];
+        const currentWorkloads = workloadsByYearRange?.[selectedYear] ?? [];
         return filterWorkloadsByPeriod(currentWorkloads, selectedPeriod, selectedDepartment);
     }, [workloadsByYearRange, selectedPeriod, selectedYear, selectedDepartment]);
 
@@ -124,6 +124,10 @@ export const WorkloadDetails: FC<Props> = ({ workloads, ratings = [], positions 
                 onDepartmentChange={setSelectedDepartment}
                 onPeriodChange={setSelectedPeriod}
             />
+
+            {filteredWorkloads.length === 0 && (
+                <SectionTitle className="mt-8 text-primary">{t('no_data')}</SectionTitle>
+            )}
 
             {sections.main.grouped.length > 0 && (
                 <div className="mt-8">


### PR DESCRIPTION
This pull request makes minor improvements to the `WorkloadDetails` component, focusing on code clarity and user feedback. The main changes are a small refactor for safer property access and the addition of a message when there is no data to display.

User experience improvements:

* Added a message (`SectionTitle` with `t('no_data')`) that is shown when there are no filtered workloads, providing clear feedback to users when no data is available. ([src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsxR128-R131](diffhunk://#diff-c7cd65917bc04dd515486cd93524b81bd7e88ae99903cccc820730e2c6837a8eR128-R131))

Code quality improvements:

* Updated the way `currentWorkloads` is accessed in the `filteredWorkloads` calculation to use optional chaining and nullish coalescing (`?.` and `??`) for safer and clearer property access. ([src/app/[locale]/(default)/profile/[teacherId]/components/WorkloadDetails/WorkloadDetails.tsxL47-R47](diffhunk://#diff-c7cd65917bc04dd515486cd93524b81bd7e88ae99903cccc820730e2c6837a8eL47-R47))